### PR TITLE
Persist auth token through cookie

### DIFF
--- a/src/BudgetSquirrel.Frontend/Authentication/AuthenticationDependencyInjection.cs
+++ b/src/BudgetSquirrel.Frontend/Authentication/AuthenticationDependencyInjection.cs
@@ -6,7 +6,7 @@ namespace BudgetSquirrel.Frontend.Authentication
 {
   public static class AuthenticationDependencyInjection
   {
-    public static IServiceCollection AddAuthenticationServices(IServiceCollection services)
+    public static IServiceCollection AddServices(IServiceCollection services)
     {
       services.AddTransient<IRegistrationService, RegistrationService>();
       services.AddSingleton<ILoginService, LoginService>();

--- a/src/BudgetSquirrel.Frontend/Authentication/Login/ILoginService.cs
+++ b/src/BudgetSquirrel.Frontend/Authentication/Login/ILoginService.cs
@@ -8,7 +8,7 @@ namespace BudgetSquirrel.Frontend.Authentication.Login
     
     Task Login(string username, string password);
 
-    void PromptLoginIfNecessary();
+    Task PromptLoginIfNecessary();
 
     bool IsAuthenticated { get; }
   }

--- a/src/BudgetSquirrel.Frontend/Authentication/Login/LoginService.cs
+++ b/src/BudgetSquirrel.Frontend/Authentication/Login/LoginService.cs
@@ -1,21 +1,29 @@
 using System;
 using System.Threading.Tasks;
 using BudgetSquirrel.Frontend.BackendClient;
+using BudgetSquirrel.Frontend.Infrastructure;
 using Microsoft.AspNetCore.Components;
 
 namespace BudgetSquirrel.Frontend.Authentication.Login
 {
   public class LoginService : ILoginService
   {
+    private const string AuthBearerTokenCookieName = "auth_token";
+
     private IBackendClient backend;
     private NavigationManager navigationManager;
+    private ICookieService cookieService;
 
     private LoginContext loginContext;
 
-    public LoginService(IBackendClient backend, NavigationManager navManager)
+    public LoginService(
+      IBackendClient backend,
+      NavigationManager navManager,
+      ICookieService cookieService)
     {
       this.backend = backend;
       this.navigationManager = navManager;
+      this.cookieService = cookieService;
       this.loginContext = LoginContext.Unknown;
     }
 
@@ -26,17 +34,41 @@ namespace BudgetSquirrel.Frontend.Authentication.Login
     public async Task Login(string username, string password)
     {
       this.loginContext = null;
-      await this.backend.Authenticate(username, password);
+      string authToken = await this.backend.Authenticate(username, password);
+      await this.cookieService.SetCookie(AuthBearerTokenCookieName, authToken, 1);
+
       LoginContextDto contextDto = await this.backend.Fetch<LoginContextDto>(BackendArea.AuthArea.ME);
       this.loginContext = contextDto.ToLoginContext();
     }
 
-    public void PromptLoginIfNecessary()
+    public async Task PromptLoginIfNecessary()
     {
+      await this.InitializeAuthentication();
       if (!this.IsAuthenticated)
       {
         this.navigationManager.NavigateTo("login");
       }
+    }
+
+    private async Task InitializeAuthentication()
+    {
+      if (this.IsAuthenticated)
+      {
+        return;
+      }
+
+      string authToken = await this.cookieService.GetCookie(AuthBearerTokenCookieName);
+      if (authToken != null)
+      {
+        this.backend.RestoreAuthentication(authToken);
+        await this.InitializeLoginContext();
+      }
+    }
+
+    private async Task InitializeLoginContext()
+    {
+      LoginContextDto contextDto = await this.backend.Fetch<LoginContextDto>(BackendArea.AuthArea.ME);
+      this.loginContext = contextDto.ToLoginContext();
     }
   }
 }

--- a/src/BudgetSquirrel.Frontend/BackendClient/BackendClient.cs
+++ b/src/BudgetSquirrel.Frontend/BackendClient/BackendClient.cs
@@ -63,11 +63,18 @@ namespace BudgetSquirrel.Frontend.BackendClient
       return JsonConvert.DeserializeObject<T>(responseData);
     }
 
-    public async Task Authenticate(string username, string password)
+    public void RestoreAuthentication(string authToken)
+    {
+      HttpClient client = this.GetClient();
+      client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+    }
+
+    public async Task<string> Authenticate(string username, string password)
     {
       HttpClient client = this.GetClient();
       string authToken = await this.backendAuthenticator.GetAuthToken(client, username, password);
       client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+      return authToken;
     }
 
     private HttpClient GetClient()

--- a/src/BudgetSquirrel.Frontend/BackendClient/IBackendClient.cs
+++ b/src/BudgetSquirrel.Frontend/BackendClient/IBackendClient.cs
@@ -6,6 +6,7 @@ namespace BudgetSquirrel.Frontend.BackendClient
   {
     Task ExecuteCommand(string endpoint, object request);
     Task<T> Fetch<T>(string endpoint);
-    Task Authenticate(string username, string password);
+    Task<string> Authenticate(string username, string password);
+    void RestoreAuthentication(string authToken);
   }
 }

--- a/src/BudgetSquirrel.Frontend/BudgetPlanning/BudgetPlanner.razor.cs
+++ b/src/BudgetSquirrel.Frontend/BudgetPlanning/BudgetPlanner.razor.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using BudgetSquirrel.Frontend.Authentication.Login;
 using Microsoft.AspNetCore.Components;
 
@@ -8,9 +9,9 @@ namespace BudgetSquirrel.Frontend.BudgetPlanning
     [Inject]
     private ILoginService loginService { get; set; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-      this.loginService.PromptLoginIfNecessary();
+      await this.loginService.PromptLoginIfNecessary();
     }
   }
 }

--- a/src/BudgetSquirrel.Frontend/Infrastructure/CookieService.cs
+++ b/src/BudgetSquirrel.Frontend/Infrastructure/CookieService.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace BudgetSquirrel.Frontend.Infrastructure
+{
+  public class CookieService : ICookieService
+  {
+    private IJSRuntime jSRuntime;
+
+    public CookieService(IJSRuntime jSRuntime)
+    {
+      this.jSRuntime = jSRuntime;
+    }
+
+    public Task<string> GetCookie(string name)
+    {
+      string setCookieInvokePath = JSRuntimeHelpers.InvokePath(JSRuntimeHelpers.ServicePathBrowserService, "getCookie");
+      return this.jSRuntime.InvokeAsync<string>(setCookieInvokePath, name).AsTask();
+    }
+
+    public Task SetCookie(string name, string value, int hours)
+    {
+      string setCookieInvokePath = JSRuntimeHelpers.InvokePath(JSRuntimeHelpers.ServicePathBrowserService, "setCookie");
+      return this.jSRuntime.InvokeAsync<object>(setCookieInvokePath, name, value, hours).AsTask();
+    }
+  }
+}

--- a/src/BudgetSquirrel.Frontend/Infrastructure/ICookieService.cs
+++ b/src/BudgetSquirrel.Frontend/Infrastructure/ICookieService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace BudgetSquirrel.Frontend.Infrastructure
+{
+  public interface ICookieService
+  {
+    Task SetCookie(string name, string value, int hours);
+
+    Task<string> GetCookie(string name);
+  }
+}

--- a/src/BudgetSquirrel.Frontend/Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/BudgetSquirrel.Frontend/Infrastructure/InfrastructureDependencyInjection.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BudgetSquirrel.Frontend.Infrastructure
+{
+  public static class InfrastructureDependencyInjection
+  {
+    public static IServiceCollection AddServices(IServiceCollection services)
+    {
+      services.AddTransient<ICookieService, CookieService>();
+
+      return services;
+    }
+  }
+}

--- a/src/BudgetSquirrel.Frontend/Infrastructure/JSRuntimeHelpers.cs
+++ b/src/BudgetSquirrel.Frontend/Infrastructure/JSRuntimeHelpers.cs
@@ -1,0 +1,12 @@
+namespace BudgetSquirrel.Frontend.Infrastructure
+{
+  public static class JSRuntimeHelpers
+  {
+    public const string ServicePathBrowserService = "window.browserService";
+
+    public static string InvokePath(string servicePath, string member)
+    {
+      return $"{servicePath}.{member}";
+    }
+  }
+}

--- a/src/BudgetSquirrel.Frontend/Startup.cs
+++ b/src/BudgetSquirrel.Frontend/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using BudgetSquirrel.Frontend.AppSettings;
 using BudgetSquirrel.Frontend.Authentication;
 using BudgetSquirrel.Frontend.BackendClient;
+using BudgetSquirrel.Frontend.Infrastructure;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,8 +19,9 @@ namespace BudgetSquirrel.Frontend
       AppSettingsBase appSettings = this.GetAppSettings(currentEnv);
       services.AddSingleton<AppSettingsBase>(appSettings);
 
+      InfrastructureDependencyInjection.AddServices(services);
       BackendDependencyInjection.AddBackendClient(services);
-      AuthenticationDependencyInjection.AddAuthenticationServices(services);
+      AuthenticationDependencyInjection.AddServices(services);
     }
 
     private AppSettingsBase GetAppSettings(string currentEnv)

--- a/src/BudgetSquirrel.Frontend/wwwroot/index.html
+++ b/src/BudgetSquirrel.Frontend/wwwroot/index.html
@@ -11,5 +11,6 @@
     <app>Loading...</app>
 
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="js/browser-service.js"></script>
 </body>
 </html>

--- a/src/BudgetSquirrel.Frontend/wwwroot/js/browser-service.js
+++ b/src/BudgetSquirrel.Frontend/wwwroot/js/browser-service.js
@@ -1,0 +1,61 @@
+(function() {
+
+  class BrowserService {
+
+    /**
+     * Sets a cookie with the given name and value and configures it to expire
+     * after the given number of hours.
+     * @param {string} name the name of the cookie to set
+     * @param {string} value the value of the cookie to set
+     * @param {int} hours number of hours until the cookie expires
+     */
+    setCookie(name, value, hours) {
+      let expires;
+      if (hours) {
+          let date = new Date();
+          date.setTime(date.getTime() + (hours * 60 * 60 * 1000));
+          expires = "; expires=" + date.toGMTString();
+      }
+      else {
+          expires = "";
+      }
+      document.cookie = name + "=" + value + expires + "; path=/";
+    }
+
+    /**
+     * Returns an object that represents the cookie with the given name. If the cookie doesn't exist,
+     * null is returned.
+     * @param {string} name the name of the cookie
+     * @returns an object with the name and value of the cookie in the keys 'name' and 'value'. If
+     * cookie doesn't exist, null is returned.
+     */
+    getCookie(name) {
+      const cookies = document.cookie.split(";").map(cookie => _parseCookie(cookie));
+      const desiredCookie = cookies.find(c => c.name == name);
+      if (desiredCookie) {
+        return desiredCookie.value;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Returns an object that represents the given individual cookie. This cookie is not
+   * the full string in document.cookie but a single individual cookie after splitting
+   * the full cookie string by semicolon.
+   * @param {string} cookie the unparsed individual cookie from document.cookie (format 'cookieName=cookieValue')
+   * @returns an object with the name and value of the cookie in the keys 'name' and 'value'.
+   */
+  function _parseCookie(cookie) {
+    return {
+      name: cookie.split("=")[0].trim(),
+      value: cookie.split("=")[1].trim()
+    };
+  }
+
+  const browserService = new BrowserService();
+
+  window.browserService = browserService;
+
+})();


### PR DESCRIPTION
Whenever a user logs in, we authenticate to the backend with a JWT token. That token was originally only stored in memory. whenever you refreshed the page or used teh browser to navigate, you reset memory, and therefor lost the token.

To solve this, whenever the frontend retrieves the token, it stores it in a cookie in the browser for the frontend. So whenever the user logs in, it grabs that cookie and, istead of prompting a login, just starts using that token and immediately fetches the user for that token.