### PR TITLE
Add button to automatically adjust planned amount

### DIFF
--- a/src/BudgetSquirrel.Frontend/BudgetPlanning/BudgetPlanningContext.cs
+++ b/src/BudgetSquirrel.Frontend/BudgetPlanning/BudgetPlanningContext.cs
@@ -47,6 +47,12 @@ namespace BudgetSquirrel.Frontend.BudgetPlanning
 
       public decimal SubBudgetsTotalPlannedAmount => this.SubFunds.Sum(f => f.Budget.PlannedAmount);
 
+      /// <summary>
+      /// Amount by which the total planned amount of the sub budgets differs from the
+      /// planned amount of this budget.
+      /// </summary>
+      public decimal SubBudgetsTotalPlannedAmountDifference => this.Budget.PlannedAmount - this.SubBudgetsTotalPlannedAmount;
+
       public IEnumerable<FundRelationships> SubFunds { get; private set; }
     }
 

--- a/src/BudgetSquirrel.Frontend/BudgetPlanning/Budgets/Budget1.razor
+++ b/src/BudgetSquirrel.Frontend/BudgetPlanning/Budgets/Budget1.razor
@@ -25,6 +25,12 @@
             delete
           </button>
         }
+        @if (this.Budget.SubBudgetsTotalPlannedAmountDifference != 0)
+        {
+          <button class="material-icons icon-button" @onclick="this.FixPlannedAmount">
+            build
+          </button>
+        }
       </div>
     </div>
     <div class="_budget-stat__container">
@@ -33,7 +39,7 @@
         <EditableText
           CssClass="@this.AmountInStatValueCssClass"
           Value="@this.State.PlannedAmount.ToString()"
-          OnChange="@this.ChangePlannedAmount"
+          OnChange="@this.ChangePlannedAmountRaw"
           Placeholder="(ex. 3000.00)"
           Type="currency"
           WidthEms=8 />

--- a/src/BudgetSquirrel.Frontend/BudgetPlanning/Budgets/Budget1.razor.cs
+++ b/src/BudgetSquirrel.Frontend/BudgetPlanning/Budgets/Budget1.razor.cs
@@ -99,20 +99,33 @@ namespace BudgetSquirrel.Frontend.BudgetPlanning.Budgets
       this.OnNameChanged.InvokeAsync(this.State);
     }
 
-    private async Task ChangePlannedAmount(string newPlannedAmountRaw)
+    private Task ChangePlannedAmountRaw(string newPlannedAmountRaw)
     {
       bool isValidFormat = decimal.TryParse(newPlannedAmountRaw, out decimal newPlannedAmount);
       if (isValidFormat)
       {
-        this.State.PlannedAmount = newPlannedAmount;
+        return this.ChangePlannedAmount(newPlannedAmount);
       }
-
-      await this.OnPlannedAmountChanged.InvokeAsync(this.State);
+      else
+      {
+        return Task.CompletedTask;
+      }
     }
 
     private Task ChangeSubBudgetPlannedAmount(IEditPlannedAmountFormValues values)
     {
       return this.OnPlannedAmountChanged.InvokeAsync(values);
+    }
+
+    private Task FixPlannedAmount()
+    {
+      return ChangePlannedAmount(this.Budget.SubBudgetsTotalPlannedAmount);
+    }
+
+    private Task ChangePlannedAmount(decimal amount)
+    {
+      this.State.PlannedAmount = amount;
+      return this.OnPlannedAmountChanged.InvokeAsync(this.State);
     }
   }
 }


### PR DESCRIPTION
If a budget's planned amount is not the same as the sum of it's childrens' planned amounts, a button with the shape of a wrench will appear that lets you automatically adjust it.

![image](https://user-images.githubusercontent.com/12044514/160251952-7a3a6dc3-6fb8-42aa-9fcd-af930f016e0d.png)
